### PR TITLE
Feat randomize gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,16 @@ Default config file `/etc/riseup-vpn.yaml`
 ---
 # /etc/riseup-vpn.yaml
 
+# if given, use it as gateway
 server: vpn07-par.riseup.net
+
+# if `server` is not set, randomly pick any server from `location`
+# location: Seattle
+
+# openvpn protocol to use. If not set, randomly pick any protocol supported by server
 protocol: udp
+
+# openvpn port to use. If not set, randomly pick any port supported by server
 port: 53
 
 # excluded_routes: list servcies that should not be routed over VPN
@@ -74,7 +82,12 @@ group: openvpn
 extra_config: |
   # emtpy extra_config
 ```
+
+`server`, `protocol` and `port` are optional. If not given, `--generate-config` will randomly pick missing parameters.
+
+
 # How to use it
+
 [![asciicast](https://asciinema.org/a/559611.svg)](https://asciinema.org/a/559611)
 # Installation (as a dev)
 

--- a/riseup_vpn_configurator/__init__.py
+++ b/riseup_vpn_configurator/__init__.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
-import sys
-import os
-import logging
 import argparse
-import json
-import yaml
-import subprocess
-import pwd
 import grp
-from jinja2 import Template
-from pathlib import Path
-import requests
-from ipaddress import ip_network
-from pyasn1_modules import pem, rfc2459
-from pyasn1.codec.der import decoder
-import psutil
-from icmplib import ping, ICMPLibError
+import json
+import logging
+import os
+import pwd
 import shutil
 import socket
-from typing import Optional, NoReturn
+import subprocess
+import sys
+from ipaddress import ip_network
+from pathlib import Path
+from typing import NoReturn, Optional
+
+import psutil
+import requests
+import yaml
+from icmplib import ICMPLibError, ping
+from jinja2 import Template
+from pyasn1.codec.der import decoder
+from pyasn1_modules import pem, rfc2459
 
 FORMAT = "%(levelname)s: %(message)s"
 logging.basicConfig(format=FORMAT, level=logging.INFO)


### PR DESCRIPTION
## Allow gateway randomization when generating configuration.

Under-specifying server configuration in `riseup-vpn.yaml` allow riseup-vpn-configurator to randomly select missing parameters.

eg:
- leaving `server` empty, and giving a `location` will pick any server from this location
- leaving `port` will pick any available port
-  ...